### PR TITLE
Update version to 2.0.0, rename to cordova-plugin-clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,12 @@
 {
-  "name": "CordovaClipboard",
-  "version": "1.0.0",
-  "description": "Clipboard",
-  "main": "index.js",
+  "name": "cordova-plugin-clipboard",
+  "version": "2.0.0",
+  "description": "Clipboard management plugin for Cordova",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HootsuiteLabs/CordovaClipboard.git"
+    "url": "git+https://github.com/Jigsaw-Code/outline-cordova-plugin-clipboard.git"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/HootsuiteLabs/CordovaClipboard/issues"
-  },
-  "homepage": "https://github.com/HootsuiteLabs/CordovaClipboard#readme"
+  "license": "MIT"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="com.verso.cordova.clipboard"
-    version="0.1.0">
+    id="cordova-plugin-clipboard"
+    version="2.0.0">
 
     <engines>
         <engine name="cordova" version=">=3.0.0" />


### PR DESCRIPTION
* Now that Cordova favors package.json over config.xml for plugin versioning, renaming the plugin and changing the id to cordova-plugin-clipboard ensures that there are no redundant plugin declarations (CordovaClipboard, com.verso.cordova.clipboard). Additionally, the plugin ID change prevents Cordova from fetching the com.verso.cordova.clipboard plugin published on npm.
* Bumping the version to 2.0.0, since the rename is not backwards compatible.